### PR TITLE
🎉 fix: Resolve Final Scores screen navigation issue

### DIFF
--- a/app/hooks/useRoundManagement.ts
+++ b/app/hooks/useRoundManagement.ts
@@ -68,7 +68,6 @@ export function useRoundManagement({
       allRounds = [...allRounds, { ...processedCurrentRound, completed: true, endTime: Date.now() }];
     }
 
-
     const playerScores = currentGame.players.map(player => {
       let totalScore = 0;
       allRounds.forEach(round => {
@@ -98,10 +97,15 @@ export function useRoundManagement({
     };
 
     contextFinishGame(finalResults); // Use context's finishGame
+    
     if (onGameEnd) {
       onGameEnd(finalResults);
     }
-    navigate("/results");
+    
+    // Small delay to ensure context state update completes before navigation
+    setTimeout(() => {
+      navigate("/results");
+    }, 50);
   }, [currentGame, completedRounds, currentRound, contextFinishGame, navigate, onGameEnd, updateRoundWithPlacements]);
 
   const handleNextRound = useCallback(() => {

--- a/app/utils/game.ts
+++ b/app/utils/game.ts
@@ -127,7 +127,7 @@ export function createNewGame(hostName: string): Game {
     status: 'waiting',
     settings: {
       maxPlayers: 8,
-      roundTimeLimit: 30000, // 30 seconds
+      roundTimeLimit: 30000,
       totalRounds: 5,
       cityDifficulty: 'easy'
     },


### PR DESCRIPTION
- Fix race condition between context state update and navigation
- Add 50ms delay before navigating to results page
- Restore normal game settings (5 rounds, 30 seconds)
- Final Results screen now displays properly with winner celebration

🤖 Generated with [Claude Code](https://claude.ai/code)