### PR TITLE
🐛 fix: Resolve iOS input bug preventing number 6 entry

### DIFF
--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -94,12 +94,17 @@ export default function Home() {
             </label>
             <input
               id="gameCode"
-              type="text"
+              type="tel"
+              inputMode="numeric"
+              pattern="[0-9]*"
               value={gameCode}
               onChange={(e) => setGameCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent text-center text-lg font-mono"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent text-center text-lg tracking-wider"
               placeholder="123456"
               maxLength={6}
+              autoComplete="off"
+              autoCorrect="off"
+              spellCheck="false"
             />
           </div>
 


### PR DESCRIPTION
- Change input type from 'text' to 'tel' for better iOS compatibility
- Add inputMode='numeric' and pattern='[0-9]*' to force number pad
- Disable autocomplete, autocorrect, and spellcheck to prevent interference
- Replace font-mono with tracking-wider to avoid font rendering issues
- Fixes specific iOS bug where number 6 key doesn't register

🤖 Generated with [Claude Code](https://claude.ai/code)