### PR TITLE
feat: Add Brazilian and US state capitals modes and fix difficulty se…

### DIFF
--- a/app/contexts/GameContext.tsx
+++ b/app/contexts/GameContext.tsx
@@ -173,6 +173,10 @@ export function GameProvider({ children }: { children: ReactNode }) {
         dispatch({ type: 'SET_GAME', payload: message.payload.game });
         break;
         
+      case 'SETTINGS_UPDATED':
+        dispatch({ type: 'SET_GAME', payload: message.payload.game });
+        break;
+        
       case 'GAME_STARTED':
       case 'ROUND_STARTED':
         dispatch({ type: 'SET_GAME', payload: message.payload.game });
@@ -357,7 +361,13 @@ export function useGame() {
   };
 
   const updateSettings = (settings: Partial<Game['settings']>) => {
+    if (!isConnected) {
+      dispatch({ type: 'SET_ERROR', payload: 'Not connected to server' });
+      return;
+    }
+    
     dispatch({ type: 'UPDATE_SETTINGS', payload: settings });
+    sendMessage('UPDATE_SETTINGS', { settings });
   };
 
   const finishGame = (finalResults: FinalResults) => {

--- a/app/data/cities.ts
+++ b/app/data/cities.ts
@@ -1175,6 +1175,703 @@ export const cities: City[] = [
     lng: 102.6331,
     population: 948477,
     difficulty: 'hard'
+  },
+
+  // Brazilian State Capitals (all 26 states + Federal District)
+  {
+    id: 'sao_paulo',
+    name: 'São Paulo',
+    country: 'Brazil',
+    lat: -23.5505,
+    lng: -46.6333,
+    population: 12325232,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'rio_de_janeiro',
+    name: 'Rio de Janeiro',
+    country: 'Brazil',
+    lat: -22.9068,
+    lng: -43.1729,
+    population: 6718903,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'belo_horizonte',
+    name: 'Belo Horizonte',
+    country: 'Brazil',
+    lat: -19.9191,
+    lng: -43.9378,
+    population: 2521564,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'salvador',
+    name: 'Salvador',
+    country: 'Brazil',
+    lat: -12.9714,
+    lng: -38.5014,
+    population: 2886698,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'fortaleza',
+    name: 'Fortaleza',
+    country: 'Brazil',
+    lat: -3.7172,
+    lng: -38.5433,
+    population: 2686612,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'recife',
+    name: 'Recife',
+    country: 'Brazil',
+    lat: -8.0476,
+    lng: -34.8770,
+    population: 1653461,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'manaus',
+    name: 'Manaus',
+    country: 'Brazil',
+    lat: -3.1190,
+    lng: -60.0217,
+    population: 2219580,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'porto_alegre',
+    name: 'Porto Alegre',
+    country: 'Brazil',
+    lat: -30.0346,
+    lng: -51.2177,
+    population: 1488252,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'goiania',
+    name: 'Goiânia',
+    country: 'Brazil',
+    lat: -16.6869,
+    lng: -49.2648,
+    population: 1536097,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'curitiba',
+    name: 'Curitiba',
+    country: 'Brazil',
+    lat: -25.4284,
+    lng: -49.2733,
+    population: 1948626,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'brasilia',
+    name: 'Brasília',
+    country: 'Brazil',
+    lat: -15.7939,
+    lng: -47.8828,
+    population: 3055149,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'vitoria',
+    name: 'Vitória',
+    country: 'Brazil',
+    lat: -20.2976,
+    lng: -40.2958,
+    population: 365855,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'florianopolis',
+    name: 'Florianópolis',
+    country: 'Brazil',
+    lat: -27.5954,
+    lng: -48.5480,
+    population: 508826,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'campo_grande',
+    name: 'Campo Grande',
+    country: 'Brazil',
+    lat: -20.4697,
+    lng: -54.6201,
+    population: 906092,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'cuiaba',
+    name: 'Cuiabá',
+    country: 'Brazil',
+    lat: -15.6014,
+    lng: -56.0979,
+    population: 650916,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'teresina',
+    name: 'Teresina',
+    country: 'Brazil',
+    lat: -5.0892,
+    lng: -42.8019,
+    population: 868075,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'sao_luis',
+    name: 'São Luís',
+    country: 'Brazil',
+    lat: -2.5307,
+    lng: -44.3068,
+    population: 1108975,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'joao_pessoa',
+    name: 'João Pessoa',
+    country: 'Brazil',
+    lat: -7.1195,
+    lng: -34.8450,
+    population: 817511,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'natal',
+    name: 'Natal',
+    country: 'Brazil',
+    lat: -5.7945,
+    lng: -35.2110,
+    population: 890480,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'maceio',
+    name: 'Maceió',
+    country: 'Brazil',
+    lat: -9.6658,
+    lng: -35.7350,
+    population: 1025360,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'aracaju',
+    name: 'Aracaju',
+    country: 'Brazil',
+    lat: -10.9472,
+    lng: -37.0731,
+    population: 664908,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'palmas',
+    name: 'Palmas',
+    country: 'Brazil',
+    lat: -10.1689,
+    lng: -48.3317,
+    population: 306296,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'rio_branco',
+    name: 'Rio Branco',
+    country: 'Brazil',
+    lat: -9.9754,
+    lng: -67.8246,
+    population: 407319,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'porto_velho',
+    name: 'Porto Velho',
+    country: 'Brazil',
+    lat: -8.7619,
+    lng: -63.9039,
+    population: 539354,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'boa_vista',
+    name: 'Boa Vista',
+    country: 'Brazil',
+    lat: 2.8235,
+    lng: -60.6758,
+    population: 419652,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'macapa',
+    name: 'Macapá',
+    country: 'Brazil',
+    lat: 0.0347,
+    lng: -51.0694,
+    population: 512902,
+    difficulty: 'brazilian_capitals'
+  },
+  {
+    id: 'belem',
+    name: 'Belém',
+    country: 'Brazil',
+    lat: -1.4558,
+    lng: -48.5044,
+    population: 1499641,
+    difficulty: 'brazilian_capitals'
+  },
+
+  // US State Capitals (all 50 states)
+  {
+    id: 'montgomery',
+    name: 'Montgomery',
+    country: 'United States',
+    lat: 32.3617,
+    lng: -86.2792,
+    population: 200603,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'juneau',
+    name: 'Juneau',
+    country: 'United States',
+    lat: 58.3019,
+    lng: -134.4197,
+    population: 32255,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'phoenix',
+    name: 'Phoenix',
+    country: 'United States',
+    lat: 33.4484,
+    lng: -112.0740,
+    population: 1680992,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'little_rock',
+    name: 'Little Rock',
+    country: 'United States',
+    lat: 34.7465,
+    lng: -92.2896,
+    population: 198606,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'sacramento',
+    name: 'Sacramento',
+    country: 'United States',
+    lat: 38.5816,
+    lng: -121.4944,
+    population: 524943,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'denver',
+    name: 'Denver',
+    country: 'United States',
+    lat: 39.7392,
+    lng: -104.9903,
+    population: 715522,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'hartford',
+    name: 'Hartford',
+    country: 'United States',
+    lat: 41.7658,
+    lng: -72.6734,
+    population: 121054,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'dover',
+    name: 'Dover',
+    country: 'United States',
+    lat: 39.1612,
+    lng: -75.5264,
+    population: 38079,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'tallahassee',
+    name: 'Tallahassee',
+    country: 'United States',
+    lat: 30.4518,
+    lng: -84.2807,
+    population: 194500,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'atlanta',
+    name: 'Atlanta',
+    country: 'United States',
+    lat: 33.7490,
+    lng: -84.3880,
+    population: 498715,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'honolulu',
+    name: 'Honolulu',
+    country: 'United States',
+    lat: 21.3099,
+    lng: -157.8581,
+    population: 350964,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'boise',
+    name: 'Boise',
+    country: 'United States',
+    lat: 43.6150,
+    lng: -116.2023,
+    population: 235684,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'springfield',
+    name: 'Springfield',
+    country: 'United States',
+    lat: 39.7817,
+    lng: -89.6501,
+    population: 114394,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'indianapolis',
+    name: 'Indianapolis',
+    country: 'United States',
+    lat: 39.7684,
+    lng: -86.1581,
+    population: 876384,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'des_moines',
+    name: 'Des Moines',
+    country: 'United States',
+    lat: 41.5868,
+    lng: -93.6250,
+    population: 215472,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'topeka',
+    name: 'Topeka',
+    country: 'United States',
+    lat: 39.0473,
+    lng: -95.6890,
+    population: 125904,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'frankfort',
+    name: 'Frankfort',
+    country: 'United States',
+    lat: 38.2009,
+    lng: -84.8733,
+    population: 28602,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'baton_rouge',
+    name: 'Baton Rouge',
+    country: 'United States',
+    lat: 30.4515,
+    lng: -91.1871,
+    population: 220236,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'augusta',
+    name: 'Augusta',
+    country: 'United States',
+    lat: 44.3106,
+    lng: -69.7795,
+    population: 18697,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'annapolis',
+    name: 'Annapolis',
+    country: 'United States',
+    lat: 38.9717,
+    lng: -76.5010,
+    population: 40812,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'boston',
+    name: 'Boston',
+    country: 'United States',
+    lat: 42.3601,
+    lng: -71.0589,
+    population: 695926,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'lansing',
+    name: 'Lansing',
+    country: 'United States',
+    lat: 42.3314,
+    lng: -84.5467,
+    population: 118210,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'saint_paul',
+    name: 'Saint Paul',
+    country: 'United States',
+    lat: 44.9537,
+    lng: -93.0900,
+    population: 308096,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'jackson',
+    name: 'Jackson',
+    country: 'United States',
+    lat: 32.2988,
+    lng: -90.1848,
+    population: 153701,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'jefferson_city',
+    name: 'Jefferson City',
+    country: 'United States',
+    lat: 38.5767,
+    lng: -92.1735,
+    population: 43228,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'helena',
+    name: 'Helena',
+    country: 'United States',
+    lat: 46.5965,
+    lng: -112.0362,
+    population: 32655,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'lincoln',
+    name: 'Lincoln',
+    country: 'United States',
+    lat: 40.8136,
+    lng: -96.7026,
+    population: 295178,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'carson_city',
+    name: 'Carson City',
+    country: 'United States',
+    lat: 39.1638,
+    lng: -119.7674,
+    population: 58639,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'concord',
+    name: 'Concord',
+    country: 'United States',
+    lat: 43.2081,
+    lng: -71.5376,
+    population: 43976,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'trenton',
+    name: 'Trenton',
+    country: 'United States',
+    lat: 40.2206,
+    lng: -74.7565,
+    population: 90871,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'santa_fe',
+    name: 'Santa Fe',
+    country: 'United States',
+    lat: 35.6870,
+    lng: -105.9378,
+    population: 87505,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'albany',
+    name: 'Albany',
+    country: 'United States',
+    lat: 42.6526,
+    lng: -73.7562,
+    population: 97856,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'raleigh',
+    name: 'Raleigh',
+    country: 'United States',
+    lat: 35.7796,
+    lng: -78.6382,
+    population: 474069,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'bismarck',
+    name: 'Bismarck',
+    country: 'United States',
+    lat: 46.8083,
+    lng: -100.7837,
+    population: 73622,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'columbus',
+    name: 'Columbus',
+    country: 'United States',
+    lat: 39.9612,
+    lng: -82.9988,
+    population: 905748,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'oklahoma_city',
+    name: 'Oklahoma City',
+    country: 'United States',
+    lat: 35.4676,
+    lng: -97.5164,
+    population: 695403,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'salem',
+    name: 'Salem',
+    country: 'United States',
+    lat: 44.9429,
+    lng: -123.0351,
+    population: 175535,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'harrisburg',
+    name: 'Harrisburg',
+    country: 'United States',
+    lat: 40.2732,
+    lng: -76.8839,
+    population: 50099,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'providence',
+    name: 'Providence',
+    country: 'United States',
+    lat: 41.8240,
+    lng: -71.4128,
+    population: 190934,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'columbia',
+    name: 'Columbia',
+    country: 'United States',
+    lat: 34.0007,
+    lng: -81.0348,
+    population: 137300,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'pierre',
+    name: 'Pierre',
+    country: 'United States',
+    lat: 44.3683,
+    lng: -100.3510,
+    population: 14091,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'nashville',
+    name: 'Nashville',
+    country: 'United States',
+    lat: 36.1627,
+    lng: -86.7816,
+    population: 689447,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'austin',
+    name: 'Austin',
+    country: 'United States',
+    lat: 30.2672,
+    lng: -97.7431,
+    population: 978908,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'salt_lake_city',
+    name: 'Salt Lake City',
+    country: 'United States',
+    lat: 40.7608,
+    lng: -111.8910,
+    population: 200567,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'montpelier',
+    name: 'Montpelier',
+    country: 'United States',
+    lat: 44.2601,
+    lng: -72.5806,
+    population: 7855,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'richmond',
+    name: 'Richmond',
+    country: 'United States',
+    lat: 37.5407,
+    lng: -77.4360,
+    population: 230436,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'olympia',
+    name: 'Olympia',
+    country: 'United States',
+    lat: 47.0379,
+    lng: -122.9015,
+    population: 55605,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'charleston',
+    name: 'Charleston',
+    country: 'United States',
+    lat: 38.3498,
+    lng: -81.6326,
+    population: 46536,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'madison',
+    name: 'Madison',
+    country: 'United States',
+    lat: 43.0731,
+    lng: -89.4012,
+    population: 269840,
+    difficulty: 'us_capitals'
+  },
+  {
+    id: 'cheyenne',
+    name: 'Cheyenne',
+    country: 'United States',
+    lat: 41.1400,
+    lng: -104.8197,
+    population: 65132,
+    difficulty: 'us_capitals'
   }
 ];
 
@@ -1182,11 +1879,11 @@ export function getRandomCity(): City {
   return cities[Math.floor(Math.random() * cities.length)];
 }
 
-export function getCitiesByDifficulty(difficulty: 'easy' | 'medium' | 'hard'): City[] {
+export function getCitiesByDifficulty(difficulty: 'easy' | 'medium' | 'hard' | 'brazilian_capitals' | 'us_capitals'): City[] {
   return cities.filter(city => city.difficulty === difficulty);
 }
 
-export function getRandomCityByDifficulty(difficulty: 'easy' | 'medium' | 'hard', usedCityIds: string[] = []): City {
+export function getRandomCityByDifficulty(difficulty: 'easy' | 'medium' | 'hard' | 'brazilian_capitals' | 'us_capitals', usedCityIds: string[] = []): City {
   const filteredCities = getCitiesByDifficulty(difficulty);
   const availableCities = filteredCities.filter(city => !usedCityIds.includes(city.id));
   

--- a/app/data/cities.ts
+++ b/app/data/cities.ts
@@ -1181,7 +1181,7 @@ export const cities: City[] = [
   {
     id: 'sao_paulo',
     name: 'São Paulo',
-    country: 'Brazil',
+    country: 'São Paulo',
     lat: -23.5505,
     lng: -46.6333,
     population: 12325232,
@@ -1190,7 +1190,7 @@ export const cities: City[] = [
   {
     id: 'rio_de_janeiro',
     name: 'Rio de Janeiro',
-    country: 'Brazil',
+    country: 'Rio de Janeiro',
     lat: -22.9068,
     lng: -43.1729,
     population: 6718903,
@@ -1199,7 +1199,7 @@ export const cities: City[] = [
   {
     id: 'belo_horizonte',
     name: 'Belo Horizonte',
-    country: 'Brazil',
+    country: 'Minas Gerais',
     lat: -19.9191,
     lng: -43.9378,
     population: 2521564,
@@ -1208,7 +1208,7 @@ export const cities: City[] = [
   {
     id: 'salvador',
     name: 'Salvador',
-    country: 'Brazil',
+    country: 'Bahia',
     lat: -12.9714,
     lng: -38.5014,
     population: 2886698,
@@ -1217,7 +1217,7 @@ export const cities: City[] = [
   {
     id: 'fortaleza',
     name: 'Fortaleza',
-    country: 'Brazil',
+    country: 'Ceará',
     lat: -3.7172,
     lng: -38.5433,
     population: 2686612,
@@ -1226,7 +1226,7 @@ export const cities: City[] = [
   {
     id: 'recife',
     name: 'Recife',
-    country: 'Brazil',
+    country: 'Pernambuco',
     lat: -8.0476,
     lng: -34.8770,
     population: 1653461,
@@ -1235,7 +1235,7 @@ export const cities: City[] = [
   {
     id: 'manaus',
     name: 'Manaus',
-    country: 'Brazil',
+    country: 'Amazonas',
     lat: -3.1190,
     lng: -60.0217,
     population: 2219580,
@@ -1244,7 +1244,7 @@ export const cities: City[] = [
   {
     id: 'porto_alegre',
     name: 'Porto Alegre',
-    country: 'Brazil',
+    country: 'Rio Grande do Sul',
     lat: -30.0346,
     lng: -51.2177,
     population: 1488252,
@@ -1253,7 +1253,7 @@ export const cities: City[] = [
   {
     id: 'goiania',
     name: 'Goiânia',
-    country: 'Brazil',
+    country: 'Goiás',
     lat: -16.6869,
     lng: -49.2648,
     population: 1536097,
@@ -1262,7 +1262,7 @@ export const cities: City[] = [
   {
     id: 'curitiba',
     name: 'Curitiba',
-    country: 'Brazil',
+    country: 'Paraná',
     lat: -25.4284,
     lng: -49.2733,
     population: 1948626,
@@ -1271,7 +1271,7 @@ export const cities: City[] = [
   {
     id: 'brasilia',
     name: 'Brasília',
-    country: 'Brazil',
+    country: 'Federal District',
     lat: -15.7939,
     lng: -47.8828,
     population: 3055149,
@@ -1280,7 +1280,7 @@ export const cities: City[] = [
   {
     id: 'vitoria',
     name: 'Vitória',
-    country: 'Brazil',
+    country: 'Espírito Santo',
     lat: -20.2976,
     lng: -40.2958,
     population: 365855,
@@ -1289,7 +1289,7 @@ export const cities: City[] = [
   {
     id: 'florianopolis',
     name: 'Florianópolis',
-    country: 'Brazil',
+    country: 'Santa Catarina',
     lat: -27.5954,
     lng: -48.5480,
     population: 508826,
@@ -1298,7 +1298,7 @@ export const cities: City[] = [
   {
     id: 'campo_grande',
     name: 'Campo Grande',
-    country: 'Brazil',
+    country: 'Mato Grosso do Sul',
     lat: -20.4697,
     lng: -54.6201,
     population: 906092,
@@ -1307,7 +1307,7 @@ export const cities: City[] = [
   {
     id: 'cuiaba',
     name: 'Cuiabá',
-    country: 'Brazil',
+    country: 'Mato Grosso',
     lat: -15.6014,
     lng: -56.0979,
     population: 650916,
@@ -1316,7 +1316,7 @@ export const cities: City[] = [
   {
     id: 'teresina',
     name: 'Teresina',
-    country: 'Brazil',
+    country: 'Piauí',
     lat: -5.0892,
     lng: -42.8019,
     population: 868075,
@@ -1325,7 +1325,7 @@ export const cities: City[] = [
   {
     id: 'sao_luis',
     name: 'São Luís',
-    country: 'Brazil',
+    country: 'Maranhão',
     lat: -2.5307,
     lng: -44.3068,
     population: 1108975,
@@ -1334,7 +1334,7 @@ export const cities: City[] = [
   {
     id: 'joao_pessoa',
     name: 'João Pessoa',
-    country: 'Brazil',
+    country: 'Paraíba',
     lat: -7.1195,
     lng: -34.8450,
     population: 817511,
@@ -1343,7 +1343,7 @@ export const cities: City[] = [
   {
     id: 'natal',
     name: 'Natal',
-    country: 'Brazil',
+    country: 'Rio Grande do Norte',
     lat: -5.7945,
     lng: -35.2110,
     population: 890480,
@@ -1352,7 +1352,7 @@ export const cities: City[] = [
   {
     id: 'maceio',
     name: 'Maceió',
-    country: 'Brazil',
+    country: 'Alagoas',
     lat: -9.6658,
     lng: -35.7350,
     population: 1025360,
@@ -1361,7 +1361,7 @@ export const cities: City[] = [
   {
     id: 'aracaju',
     name: 'Aracaju',
-    country: 'Brazil',
+    country: 'Sergipe',
     lat: -10.9472,
     lng: -37.0731,
     population: 664908,
@@ -1370,7 +1370,7 @@ export const cities: City[] = [
   {
     id: 'palmas',
     name: 'Palmas',
-    country: 'Brazil',
+    country: 'Tocantins',
     lat: -10.1689,
     lng: -48.3317,
     population: 306296,
@@ -1379,7 +1379,7 @@ export const cities: City[] = [
   {
     id: 'rio_branco',
     name: 'Rio Branco',
-    country: 'Brazil',
+    country: 'Acre',
     lat: -9.9754,
     lng: -67.8246,
     population: 407319,
@@ -1388,7 +1388,7 @@ export const cities: City[] = [
   {
     id: 'porto_velho',
     name: 'Porto Velho',
-    country: 'Brazil',
+    country: 'Rondônia',
     lat: -8.7619,
     lng: -63.9039,
     population: 539354,
@@ -1397,7 +1397,7 @@ export const cities: City[] = [
   {
     id: 'boa_vista',
     name: 'Boa Vista',
-    country: 'Brazil',
+    country: 'Roraima',
     lat: 2.8235,
     lng: -60.6758,
     population: 419652,
@@ -1406,7 +1406,7 @@ export const cities: City[] = [
   {
     id: 'macapa',
     name: 'Macapá',
-    country: 'Brazil',
+    country: 'Amapá',
     lat: 0.0347,
     lng: -51.0694,
     population: 512902,
@@ -1415,7 +1415,7 @@ export const cities: City[] = [
   {
     id: 'belem',
     name: 'Belém',
-    country: 'Brazil',
+    country: 'Pará',
     lat: -1.4558,
     lng: -48.5044,
     population: 1499641,
@@ -1426,7 +1426,7 @@ export const cities: City[] = [
   {
     id: 'montgomery',
     name: 'Montgomery',
-    country: 'United States',
+    country: 'Alabama',
     lat: 32.3617,
     lng: -86.2792,
     population: 200603,
@@ -1435,7 +1435,7 @@ export const cities: City[] = [
   {
     id: 'juneau',
     name: 'Juneau',
-    country: 'United States',
+    country: 'Alaska',
     lat: 58.3019,
     lng: -134.4197,
     population: 32255,
@@ -1444,7 +1444,7 @@ export const cities: City[] = [
   {
     id: 'phoenix',
     name: 'Phoenix',
-    country: 'United States',
+    country: 'Arizona',
     lat: 33.4484,
     lng: -112.0740,
     population: 1680992,
@@ -1453,7 +1453,7 @@ export const cities: City[] = [
   {
     id: 'little_rock',
     name: 'Little Rock',
-    country: 'United States',
+    country: 'Arkansas',
     lat: 34.7465,
     lng: -92.2896,
     population: 198606,
@@ -1462,7 +1462,7 @@ export const cities: City[] = [
   {
     id: 'sacramento',
     name: 'Sacramento',
-    country: 'United States',
+    country: 'California',
     lat: 38.5816,
     lng: -121.4944,
     population: 524943,
@@ -1471,7 +1471,7 @@ export const cities: City[] = [
   {
     id: 'denver',
     name: 'Denver',
-    country: 'United States',
+    country: 'Colorado',
     lat: 39.7392,
     lng: -104.9903,
     population: 715522,
@@ -1480,7 +1480,7 @@ export const cities: City[] = [
   {
     id: 'hartford',
     name: 'Hartford',
-    country: 'United States',
+    country: 'Connecticut',
     lat: 41.7658,
     lng: -72.6734,
     population: 121054,
@@ -1489,7 +1489,7 @@ export const cities: City[] = [
   {
     id: 'dover',
     name: 'Dover',
-    country: 'United States',
+    country: 'Delaware',
     lat: 39.1612,
     lng: -75.5264,
     population: 38079,
@@ -1498,7 +1498,7 @@ export const cities: City[] = [
   {
     id: 'tallahassee',
     name: 'Tallahassee',
-    country: 'United States',
+    country: 'Florida',
     lat: 30.4518,
     lng: -84.2807,
     population: 194500,
@@ -1507,7 +1507,7 @@ export const cities: City[] = [
   {
     id: 'atlanta',
     name: 'Atlanta',
-    country: 'United States',
+    country: 'Georgia',
     lat: 33.7490,
     lng: -84.3880,
     population: 498715,
@@ -1516,7 +1516,7 @@ export const cities: City[] = [
   {
     id: 'honolulu',
     name: 'Honolulu',
-    country: 'United States',
+    country: 'Hawaii',
     lat: 21.3099,
     lng: -157.8581,
     population: 350964,
@@ -1525,7 +1525,7 @@ export const cities: City[] = [
   {
     id: 'boise',
     name: 'Boise',
-    country: 'United States',
+    country: 'Idaho',
     lat: 43.6150,
     lng: -116.2023,
     population: 235684,
@@ -1534,7 +1534,7 @@ export const cities: City[] = [
   {
     id: 'springfield',
     name: 'Springfield',
-    country: 'United States',
+    country: 'Illinois',
     lat: 39.7817,
     lng: -89.6501,
     population: 114394,
@@ -1543,7 +1543,7 @@ export const cities: City[] = [
   {
     id: 'indianapolis',
     name: 'Indianapolis',
-    country: 'United States',
+    country: 'Indiana',
     lat: 39.7684,
     lng: -86.1581,
     population: 876384,
@@ -1552,7 +1552,7 @@ export const cities: City[] = [
   {
     id: 'des_moines',
     name: 'Des Moines',
-    country: 'United States',
+    country: 'Iowa',
     lat: 41.5868,
     lng: -93.6250,
     population: 215472,
@@ -1561,7 +1561,7 @@ export const cities: City[] = [
   {
     id: 'topeka',
     name: 'Topeka',
-    country: 'United States',
+    country: 'Kansas',
     lat: 39.0473,
     lng: -95.6890,
     population: 125904,
@@ -1570,7 +1570,7 @@ export const cities: City[] = [
   {
     id: 'frankfort',
     name: 'Frankfort',
-    country: 'United States',
+    country: 'Kentucky',
     lat: 38.2009,
     lng: -84.8733,
     population: 28602,
@@ -1579,7 +1579,7 @@ export const cities: City[] = [
   {
     id: 'baton_rouge',
     name: 'Baton Rouge',
-    country: 'United States',
+    country: 'Louisiana',
     lat: 30.4515,
     lng: -91.1871,
     population: 220236,
@@ -1588,7 +1588,7 @@ export const cities: City[] = [
   {
     id: 'augusta',
     name: 'Augusta',
-    country: 'United States',
+    country: 'Maine',
     lat: 44.3106,
     lng: -69.7795,
     population: 18697,
@@ -1597,7 +1597,7 @@ export const cities: City[] = [
   {
     id: 'annapolis',
     name: 'Annapolis',
-    country: 'United States',
+    country: 'Maryland',
     lat: 38.9717,
     lng: -76.5010,
     population: 40812,
@@ -1606,7 +1606,7 @@ export const cities: City[] = [
   {
     id: 'boston',
     name: 'Boston',
-    country: 'United States',
+    country: 'Massachusetts',
     lat: 42.3601,
     lng: -71.0589,
     population: 695926,
@@ -1615,7 +1615,7 @@ export const cities: City[] = [
   {
     id: 'lansing',
     name: 'Lansing',
-    country: 'United States',
+    country: 'Michigan',
     lat: 42.3314,
     lng: -84.5467,
     population: 118210,
@@ -1624,7 +1624,7 @@ export const cities: City[] = [
   {
     id: 'saint_paul',
     name: 'Saint Paul',
-    country: 'United States',
+    country: 'Minnesota',
     lat: 44.9537,
     lng: -93.0900,
     population: 308096,
@@ -1633,7 +1633,7 @@ export const cities: City[] = [
   {
     id: 'jackson',
     name: 'Jackson',
-    country: 'United States',
+    country: 'Mississippi',
     lat: 32.2988,
     lng: -90.1848,
     population: 153701,
@@ -1642,7 +1642,7 @@ export const cities: City[] = [
   {
     id: 'jefferson_city',
     name: 'Jefferson City',
-    country: 'United States',
+    country: 'Missouri',
     lat: 38.5767,
     lng: -92.1735,
     population: 43228,
@@ -1651,7 +1651,7 @@ export const cities: City[] = [
   {
     id: 'helena',
     name: 'Helena',
-    country: 'United States',
+    country: 'Montana',
     lat: 46.5965,
     lng: -112.0362,
     population: 32655,
@@ -1660,7 +1660,7 @@ export const cities: City[] = [
   {
     id: 'lincoln',
     name: 'Lincoln',
-    country: 'United States',
+    country: 'Nebraska',
     lat: 40.8136,
     lng: -96.7026,
     population: 295178,
@@ -1669,7 +1669,7 @@ export const cities: City[] = [
   {
     id: 'carson_city',
     name: 'Carson City',
-    country: 'United States',
+    country: 'Nevada',
     lat: 39.1638,
     lng: -119.7674,
     population: 58639,
@@ -1678,7 +1678,7 @@ export const cities: City[] = [
   {
     id: 'concord',
     name: 'Concord',
-    country: 'United States',
+    country: 'New Hampshire',
     lat: 43.2081,
     lng: -71.5376,
     population: 43976,
@@ -1687,7 +1687,7 @@ export const cities: City[] = [
   {
     id: 'trenton',
     name: 'Trenton',
-    country: 'United States',
+    country: 'New Jersey',
     lat: 40.2206,
     lng: -74.7565,
     population: 90871,
@@ -1696,7 +1696,7 @@ export const cities: City[] = [
   {
     id: 'santa_fe',
     name: 'Santa Fe',
-    country: 'United States',
+    country: 'New Mexico',
     lat: 35.6870,
     lng: -105.9378,
     population: 87505,
@@ -1705,7 +1705,7 @@ export const cities: City[] = [
   {
     id: 'albany',
     name: 'Albany',
-    country: 'United States',
+    country: 'New York',
     lat: 42.6526,
     lng: -73.7562,
     population: 97856,
@@ -1714,7 +1714,7 @@ export const cities: City[] = [
   {
     id: 'raleigh',
     name: 'Raleigh',
-    country: 'United States',
+    country: 'North Carolina',
     lat: 35.7796,
     lng: -78.6382,
     population: 474069,
@@ -1723,7 +1723,7 @@ export const cities: City[] = [
   {
     id: 'bismarck',
     name: 'Bismarck',
-    country: 'United States',
+    country: 'North Dakota',
     lat: 46.8083,
     lng: -100.7837,
     population: 73622,
@@ -1732,7 +1732,7 @@ export const cities: City[] = [
   {
     id: 'columbus',
     name: 'Columbus',
-    country: 'United States',
+    country: 'Ohio',
     lat: 39.9612,
     lng: -82.9988,
     population: 905748,
@@ -1741,7 +1741,7 @@ export const cities: City[] = [
   {
     id: 'oklahoma_city',
     name: 'Oklahoma City',
-    country: 'United States',
+    country: 'Oklahoma',
     lat: 35.4676,
     lng: -97.5164,
     population: 695403,
@@ -1750,7 +1750,7 @@ export const cities: City[] = [
   {
     id: 'salem',
     name: 'Salem',
-    country: 'United States',
+    country: 'Oregon',
     lat: 44.9429,
     lng: -123.0351,
     population: 175535,
@@ -1759,7 +1759,7 @@ export const cities: City[] = [
   {
     id: 'harrisburg',
     name: 'Harrisburg',
-    country: 'United States',
+    country: 'Pennsylvania',
     lat: 40.2732,
     lng: -76.8839,
     population: 50099,
@@ -1768,7 +1768,7 @@ export const cities: City[] = [
   {
     id: 'providence',
     name: 'Providence',
-    country: 'United States',
+    country: 'Rhode Island',
     lat: 41.8240,
     lng: -71.4128,
     population: 190934,
@@ -1777,7 +1777,7 @@ export const cities: City[] = [
   {
     id: 'columbia',
     name: 'Columbia',
-    country: 'United States',
+    country: 'South Carolina',
     lat: 34.0007,
     lng: -81.0348,
     population: 137300,
@@ -1786,7 +1786,7 @@ export const cities: City[] = [
   {
     id: 'pierre',
     name: 'Pierre',
-    country: 'United States',
+    country: 'South Dakota',
     lat: 44.3683,
     lng: -100.3510,
     population: 14091,
@@ -1795,7 +1795,7 @@ export const cities: City[] = [
   {
     id: 'nashville',
     name: 'Nashville',
-    country: 'United States',
+    country: 'Tennessee',
     lat: 36.1627,
     lng: -86.7816,
     population: 689447,
@@ -1804,7 +1804,7 @@ export const cities: City[] = [
   {
     id: 'austin',
     name: 'Austin',
-    country: 'United States',
+    country: 'Texas',
     lat: 30.2672,
     lng: -97.7431,
     population: 978908,
@@ -1813,7 +1813,7 @@ export const cities: City[] = [
   {
     id: 'salt_lake_city',
     name: 'Salt Lake City',
-    country: 'United States',
+    country: 'Utah',
     lat: 40.7608,
     lng: -111.8910,
     population: 200567,
@@ -1822,7 +1822,7 @@ export const cities: City[] = [
   {
     id: 'montpelier',
     name: 'Montpelier',
-    country: 'United States',
+    country: 'Vermont',
     lat: 44.2601,
     lng: -72.5806,
     population: 7855,
@@ -1831,7 +1831,7 @@ export const cities: City[] = [
   {
     id: 'richmond',
     name: 'Richmond',
-    country: 'United States',
+    country: 'Virginia',
     lat: 37.5407,
     lng: -77.4360,
     population: 230436,
@@ -1840,7 +1840,7 @@ export const cities: City[] = [
   {
     id: 'olympia',
     name: 'Olympia',
-    country: 'United States',
+    country: 'Washington',
     lat: 47.0379,
     lng: -122.9015,
     population: 55605,
@@ -1849,7 +1849,7 @@ export const cities: City[] = [
   {
     id: 'charleston',
     name: 'Charleston',
-    country: 'United States',
+    country: 'West Virginia',
     lat: 38.3498,
     lng: -81.6326,
     population: 46536,
@@ -1858,7 +1858,7 @@ export const cities: City[] = [
   {
     id: 'madison',
     name: 'Madison',
-    country: 'United States',
+    country: 'Wisconsin',
     lat: 43.0731,
     lng: -89.4012,
     population: 269840,
@@ -1867,7 +1867,7 @@ export const cities: City[] = [
   {
     id: 'cheyenne',
     name: 'Cheyenne',
-    country: 'United States',
+    country: 'Wyoming',
     lat: 41.1400,
     lng: -104.8197,
     population: 65132,

--- a/app/routes/lobby.tsx
+++ b/app/routes/lobby.tsx
@@ -154,21 +154,22 @@ export default function Lobby() {
                       City Difficulty
                     </label>
                     <div className="space-y-2">
-                      {(['easy', 'medium', 'hard'] as const).map((difficulty) => (
+                      {(['easy', 'medium', 'hard', 'brazilian_capitals', 'us_capitals'] as const).map((difficulty) => (
                         <label key={difficulty} className="flex items-center cursor-pointer">
                           <input
                             type="radio"
                             name="difficulty"
                             value={difficulty}
                             checked={currentGame.settings.cityDifficulty === difficulty}
-                            onChange={(e) => updateSettings({ cityDifficulty: e.target.value as 'easy' | 'medium' | 'hard' })}
+                            onChange={(e) => updateSettings({ cityDifficulty: e.target.value as 'easy' | 'medium' | 'hard' | 'brazilian_capitals' | 'us_capitals' })}
                             className="mr-3 text-blue-600 focus:ring-blue-500"
                           />
-                          <span className="text-sm text-gray-700 capitalize">
-                            {difficulty}
-                            {difficulty === 'easy' && ' - Famous world cities'}
-                            {difficulty === 'medium' && ' - Regional capitals'}
-                            {difficulty === 'hard' && ' - Lesser-known cities'}
+                          <span className="text-sm text-gray-700">
+                            {difficulty === 'easy' && 'Easy - Famous world cities'}
+                            {difficulty === 'medium' && 'Medium - Regional capitals'}
+                            {difficulty === 'hard' && 'Hard - Lesser-known cities'}
+                            {difficulty === 'brazilian_capitals' && 'Brazilian State Capitals'}
+                            {difficulty === 'us_capitals' && 'US State Capitals'}
                           </span>
                         </label>
                       ))}
@@ -179,7 +180,13 @@ export default function Lobby() {
                 {!isHost && (
                   <div className="flex justify-between">
                     <span className="text-gray-600">City difficulty:</span>
-                    <span className="font-semibold capitalize">{currentGame.settings.cityDifficulty}</span>
+                    <span className="font-semibold">
+                      {currentGame.settings.cityDifficulty === 'easy' && 'Easy'}
+                      {currentGame.settings.cityDifficulty === 'medium' && 'Medium'}
+                      {currentGame.settings.cityDifficulty === 'hard' && 'Hard'}
+                      {currentGame.settings.cityDifficulty === 'brazilian_capitals' && 'Brazilian State Capitals'}
+                      {currentGame.settings.cityDifficulty === 'us_capitals' && 'US State Capitals'}
+                    </span>
                   </div>
                 )}
               </div>

--- a/app/server/database.ts
+++ b/app/server/database.ts
@@ -152,6 +152,14 @@ export class GameDatabase {
     stmt.run(JSON.stringify(finalResults), Date.now(), gameId);
   }
 
+  updateGameSettings(gameId: string, settings: Game['settings']): void {
+    const stmt = this.db.prepare(`
+      UPDATE games SET settings = ?, updated_at = ? WHERE id = ?
+    `);
+    
+    stmt.run(JSON.stringify(settings), Date.now(), gameId);
+  }
+
   // Player operations
   addPlayer(gameId: string, player: Player): void {
     const stmt = this.db.prepare(`

--- a/app/server/game-manager.ts
+++ b/app/server/game-manager.ts
@@ -468,7 +468,7 @@ export class GameManager {
     return { success: true };
   }
 
-  private createNewRound(gameId: string, difficulty: 'easy' | 'medium' | 'hard', usedCityIds: string[]): GameRound {
+  private createNewRound(gameId: string, difficulty: 'easy' | 'medium' | 'hard' | 'brazilian_capitals' | 'us_capitals', usedCityIds: string[]): GameRound {
     const city = getRandomCityByDifficulty(difficulty, usedCityIds);
     
     const round: GameRound = {

--- a/app/server/game-manager.ts
+++ b/app/server/game-manager.ts
@@ -445,6 +445,41 @@ export class GameManager {
     };
   }
 
+  updateSettings(gameId: string, playerId: string, settings: Partial<Game['settings']>): GameResult {
+    const game = this.db.getGameById(gameId);
+    
+    if (!game) {
+      return { success: false, error: 'Game not found' };
+    }
+    
+    // Only the host can update settings
+    if (game.hostId !== playerId) {
+      return { success: false, error: 'Only the host can update settings' };
+    }
+    
+    // Only allow settings changes before the game starts
+    if (game.status !== 'waiting') {
+      return { success: false, error: 'Settings can only be changed before the game starts' };
+    }
+    
+    // Update the settings
+    const updatedSettings = {
+      ...game.settings,
+      ...settings
+    };
+    
+    // Update in database
+    this.db.updateGameSettings(gameId, updatedSettings);
+    
+    // Get the updated game
+    const updatedGame = this.db.getGameById(gameId);
+    
+    return { 
+      success: true, 
+      game: updatedGame! 
+    };
+  }
+
   removePlayer(gameId: string, playerId: string): GameResult {
     const game = this.db.getGameById(gameId);
     

--- a/app/types/game.ts
+++ b/app/types/game.ts
@@ -5,7 +5,7 @@ export interface City {
   lat: number;
   lng: number;
   population: number;
-  difficulty: 'easy' | 'medium' | 'hard';
+  difficulty: 'easy' | 'medium' | 'hard' | 'brazilian_capitals' | 'us_capitals';
 }
 
 export interface Player {
@@ -61,7 +61,7 @@ export interface Game {
     maxPlayers: number;
     roundTimeLimit: number;
     totalRounds: number;
-    cityDifficulty: 'easy' | 'medium' | 'hard';
+    cityDifficulty: 'easy' | 'medium' | 'hard' | 'brazilian_capitals' | 'us_capitals';
   };
   finalResults?: FinalResults;
   createdAt: number;

--- a/app/utils/game.ts
+++ b/app/utils/game.ts
@@ -65,7 +65,9 @@ export function generateComputerGuess(city: City, accuracy: number): { lat: numb
   const difficultyMultipliers = {
     'easy': 0.8,    // 80% accuracy for well-known cities
     'medium': 0.5,  // 50% accuracy for medium cities  
-    'hard': 0.2     // 20% accuracy for obscure cities
+    'hard': 0.2,    // 20% accuracy for obscure cities
+    'brazilian_capitals': 0.4,  // 40% accuracy for Brazilian state capitals
+    'us_capitals': 0.4     // 40% accuracy for US state capitals
   };
   
   const difficultyMultiplier = difficultyMultipliers[city.difficulty];


### PR DESCRIPTION
…lection persistence

- Fix radio button jumping back to easy after submit by adding WebSocket synchronization
- Add support for Brazilian state capitals mode with all 27 capitals
- Add support for US state capitals mode with all 50 state capitals
- Update type definitions to include new difficulty modes
- Fix server-side settings update handling with SETTINGS_UPDATED message
- Add difficulty multipliers for new modes (40% accuracy for computer players)
- Update lobby UI to display proper labels for all difficulty modes

Closes #33

🤖 Generated with [Claude Code](https://claude.ai/code)